### PR TITLE
fix unsecure route

### DIFF
--- a/lib/devise_sms_activable/routes.rb
+++ b/lib/devise_sms_activable/routes.rb
@@ -4,7 +4,7 @@ module ActionDispatch::Routing
     protected
       def devise_sms_activation(mapping, controllers)
         resource :sms_activation, :only => [:new, :create], :path => mapping.path_names[:sms_activation], :controller => controllers[:sms_activations] do
-          match :consume, :path => mapping.path_names[:consume], :as => :consume
+          match :consume, :path => mapping.path_names[:consume], :as => :consume, :via => [:get, :post]
           get :insert, :path => mapping.path_names[:insert], :as => :insert
         end
       end


### PR DESCRIPTION
closes #6 

http method type needs to be declared when using `match` by `via` parameter. It occurs an error without declaring.
